### PR TITLE
Fixed a bug causing the bombs to not appear

### DIFF
--- a/site.js
+++ b/site.js
@@ -96,7 +96,7 @@ function ShowMole(idx) {
     }
     else
     {
-        if (hardMode && molesTillBomb == 0)
+        if (hardMode && molesTillBomb <= 0)
         {
             hole.classList.remove("golden-mole");
             hole.classList.remove("mole");


### PR DESCRIPTION
If the golden mole and the bomb needed to appear at the same time, the `molesTillBomb` would become negative and since the check for deploying a bomb was `molesTillBomb == 0` it would fail to deploy bombs